### PR TITLE
Fix network store server default url

### DIFF
--- a/geo-data-server/src/main/resources/application.yml
+++ b/geo-data-server/src/main/resources/application.yml
@@ -2,7 +2,7 @@ server:
   port : 8087
 
 network-store-server:
-   base-uri: http://dev-master.pgs.rte-france.com/network-store-server/
+   base-uri: http://localhost:8080
    preloading-strategy: COLLECTION
 
 network-geo-data:


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Network store server default URL is incorrect.


**What is the new behavior (if this is a feature change)?**
Network store server default URL is now localhost for dev testing.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
