### PR TITLE
Add methods to get all geo data

### DIFF
--- a/geo-data-server/src/main/java/com/powsybl/geodata/server/GeoDataController.java
+++ b/geo-data-server/src/main/java/com/powsybl/geodata/server/GeoDataController.java
@@ -49,6 +49,13 @@ public class GeoDataController {
     }
 
     @GetMapping(value = "/substations", produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiOperation(value = "Get all substations geographical data", response = List.class)
+    @ApiResponses(value = {@ApiResponse(code = 200, message = "All substations geographical data")})
+    public ResponseEntity<List<SubstationGeoData>> getSubstations() {
+        return ResponseEntity.ok().body(geoDataService.getSubstations());
+    }
+
+    @GetMapping(value = "/substations/{networkUuid}", produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation(value = "Get substations geographical data", response = List.class)
     @ApiResponses(value = {@ApiResponse(code = 200, message = "Substations geographical data")})
     public ResponseEntity<List<SubstationGeoData>> getSubstations(@RequestParam UUID networkUuid,
@@ -60,6 +67,13 @@ public class GeoDataController {
     }
 
     @GetMapping(value = "/lines", produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiOperation(value = "Get all lines geographical data", response = List.class)
+    @ApiResponses(value = {@ApiResponse(code = 200, message = "All lines geographical data")})
+    public ResponseEntity<List<LineGeoData>> getLines() {
+        return ResponseEntity.ok().body(geoDataService.getLines());
+    }
+
+    @GetMapping(value = "/lines/{networkUuid}", produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation(value = "Get lines geographical data", response = List.class)
     @ApiResponses(value = {@ApiResponse(code = 200, message = "Lines geographical data")})
     public ResponseEntity<List<LineGeoData>> getLines(@RequestParam UUID networkUuid,

--- a/geo-data-server/src/main/java/com/powsybl/geodata/server/GeoDataService.java
+++ b/geo-data-server/src/main/java/com/powsybl/geodata/server/GeoDataService.java
@@ -60,6 +60,11 @@ public class GeoDataService {
         return substationsGeoDataDB;
     }
 
+    List<SubstationGeoData> getSubstations() {
+        LOGGER.info("Loading all substations geo data");
+        return new ArrayList<>(readSubstationGeoDataFromDb(null).values());
+    }
+
     List<SubstationGeoData> getSubstations(Network network, Set<Country> countries) {
         LOGGER.info("Loading substations geo data for countries {} of network '{}'", countries, network.getId());
 
@@ -234,6 +239,12 @@ public class GeoDataService {
             }
         }
         lineRepository.saveAll(linesEntities);
+    }
+
+    List<LineGeoData> getLines() {
+        LOGGER.info("Loading all lines geo data");
+
+        return new ArrayList<>(lineCustomRepository.getLines().values());
     }
 
     List<LineGeoData> getLines(Network network, Set<Country> countries) {


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
feature


**What is the current behavior?** *(You can also link to an open issue here)*
There is no way to get all geo data. we need to pass a network uuid to filter geo data for a particular network.


**What is the new behavior (if this is a feature change)?**
I added 2 methods to get all substation and line data. 


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
