### PR TITLE
upgrade to surefire 2.22.2 to fix 'corrupted STDOUT' warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <maven.jib.version>1.8.0</maven.jib.version>
         <maven.resources.version>3.1.0</maven.resources.version>
         <maven.site.version>3.7.1</maven.site.version>
-        <maven.surefire.version>2.22.0</maven.surefire.version>
+        <maven.surefire.version>2.22.2</maven.surefire.version>
 
         <datastax.java-driver.version>4.5.1</datastax.java-driver.version>
         <embedded-cassandra.version>3.0.3</embedded-cassandra.version>


### PR DESCRIPTION
Signed-off-by: Jon Harper <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Running the tests, you get the warning
"Corrupted STDOUT by directly writing to native stream in forked JVM ..."


**What is the new behavior (if this is a feature change)?**
no warning


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO