### PR TITLE
upgrade to cassandra-4.0-alpha4, alpha3 is no longer available

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,16 +16,16 @@ jobs:
         with:
           java-version: 11
 
-      - name: Download cassandra 4.0-alpha3
-        run: cd && wget "https://downloads.apache.org/cassandra/4.0-alpha3/apache-cassandra-4.0-alpha3-bin.tar.gz"
+      - name: Download cassandra 4.0-alpha4
+        run: cd && wget "https://downloads.apache.org/cassandra/4.0-alpha4/apache-cassandra-4.0-alpha4-bin.tar.gz"
 
       - name: Untar cassandra
-        run: cd && tar xvzf apache-cassandra-4.0-alpha3-bin.tar.gz
+        run: cd && tar xvzf apache-cassandra-4.0-alpha4-bin.tar.gz
 
       - name: Enable materialized view and change cassandra storage port
         run: >
           cd
-          && cd ./apache-cassandra-4.0-alpha3/conf/
+          && cd ./apache-cassandra-4.0-alpha4/conf/
           && sed -i 's/- seeds: "127.0.0.1:7000"/- seeds: "127.0.0.1:16432"/' ./cassandra.yaml
 
       - name: Checkout network store sources

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 
 ### Run integration tests
 
-To run the integration tests, you need to install a [Cassandra 4.0-alpha3](https://downloads.apache.org/cassandra/4.0-alpha3/) in your home directory.
+To run the integration tests, you need to install a [Cassandra 4.0-alpha4](https://downloads.apache.org/cassandra/4.0-alpha4/) in your home directory.
 
-When it's done you'll have to modify some configuration in the cassandra you just installed. Go to the ~/apache-cassandra-4.0-alpha3/conf/cassandra.yaml file and enable the materialized views by changing :
+When it's done you'll have to modify some configuration in the cassandra you just installed. Go to the ~/apache-cassandra-4.0-alpha4/conf/cassandra.yaml file and enable the materialized views by changing :
 
 ```yaml
 enable_materialized_views: false

--- a/geo-data-server/src/test/java/com/powsybl/geodata/server/EmbeddedCassandraFactoryConfig.java
+++ b/geo-data-server/src/test/java/com/powsybl/geodata/server/EmbeddedCassandraFactoryConfig.java
@@ -30,8 +30,8 @@ public class EmbeddedCassandraFactoryConfig {
     @Scope("singleton")
     CassandraFactory embeddedCassandraFactory() throws UnknownHostException {
         EmbeddedCassandraFactory cassandraFactory = new EmbeddedCassandraFactory();
-        Version version = Version.of("4.0-alpha3");
-        Path directory = Paths.get(System.getProperty("user.home") + "/apache-cassandra-4.0-alpha3");
+        Version version = Version.of("4.0-alpha4");
+        Path directory = Paths.get(System.getProperty("user.home") + "/apache-cassandra-4.0-alpha4");
         if (!Files.isDirectory(directory)) {
             throw new IllegalStateException("directory : " + directory + " doesn't exist. You must install a cassandra in your home directory to run the integrations tests");
         }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug Fix


**What is the current behavior?** *(You can also link to an open issue here)*
CI fails and documentation is out of date because casssandra-4-alpha3 is not longer downloadable


**What is the new behavior (if this is a feature change)?**
using cassandra-4-alpha4


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
no
